### PR TITLE
feat(test): support for neotest and commands to run neotest in venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ return {
 
 </details>
 
-<summary>Configuration Options</summary>
-
 <details>
+<summary>Configuration Options</summary>
 
 ```lua
 return {
@@ -183,4 +182,7 @@ return {
 Use this plugin if you want a more simple venv management plugin for your workflow.
 
 [go.nvim](https://github.com/ray-x/go.nvim) for inspiration.
+
+```
+
 ```

--- a/README.md
+++ b/README.md
@@ -52,6 +52,72 @@ return {
 
 </details>
 
+<summary>Configuration Options</summary>
+
+<details>
+
+```lua
+return {
+  ---@module 'python'
+  {
+    "joshzcold/python.nvim",
+    ---@type python.Config
+    opts = { ---@diagnostic disable-line: missing-fields`
+        -- Should return a list of tables with a `name` and a `path` entry each.
+        -- Gets the argument `venvs_path` set below.
+        -- By default just lists the entries in `venvs_path`.
+        ---@return VEnv[]
+        get_venvs = function(venvs_path)
+            return require('python.venv').get_venvs(venvs_path)
+        end,
+        -- Path for venvs picker
+        venvs_path = vim.fn.expand('~/.virtualenvs'),
+        -- Something to do after setting an environment
+        post_set_venv = nil,
+        -- base path for creating new venvs
+        auto_create_venv_path = function(parent_dir)
+            return vim.fs.joinpath(parent_dir, '.venv')
+        end,
+        -- Patterns for autocmd LspAttach that trigger the auto venv logic
+        -- Add onto this list if you depend on venvs for other file types
+        -- like .yaml, .yml for ansible
+        auto_venv_lsp_attach_patterns = { "*.py" },
+
+        -- Filetypes to activate commands for python.nvim
+        command_setup_filetypes = { "python" },
+
+        -- Load python.nvim python snippets
+        python_lua_snippets = false,
+
+        -- Settings regarding ui handling
+        ui = {
+            -- Amount of time to pause closing of ui after a finished task
+            ui_close_timeout = 5000,
+            -- zindex of new ui elements.
+            zindex = 999,
+            -- Default ui style for interfaces created by python.nvim
+            ---@alias python_ui_default_style "'popup'|nil"
+            default_ui_style = "popup",
+            popup = {
+            demensions = {
+                width = "60",
+                height = "25"
+            }
+            }
+        },
+
+        -- Tell neotest-python which test runner to use
+        test = {
+            test_runner = "pytest"
+        }
+    }
+  }
+}
+
+```
+
+</details>
+
 ## Features
 
 - [x] Switch between virtual envs interactively
@@ -74,6 +140,8 @@ return {
 
 - [x] Optional Python Snippets through luasnip
 
+- [x] Integration with neotest. Commands to easily run tests through venv setup with `python.nvim`
+
 - [ ] Treesitter integration
   - [ ] Functions utilizing treesitter for helpful code actions
 
@@ -85,15 +153,19 @@ return {
 | -------------------- | ------------------------------------------------------------------------------------ |
 | `:PythonVEnvInstall` | Create a venv and install dependencies if a supported python package format is found |
 | `:PythonDap`         | Create and save a new Dap configuration                                              |
+| `:PythonTest`        | Run Suite of tests with `neotest`                                                    |
+| `:PythonTestMethod`  | Run test function/method with `neotest`                                              |
+| `:PythonTestFile`    | Run test file with `neotest`                                                         |
 
 ## Advanced Commands
 
-| Command                      | Functionality                                                  |
-| ---------------------------- | -------------------------------------------------------------- |
-| `:PythonVEnvDeleteSelect`    | Select a venv to delete from `python.nvim` state               |
-| `:PythonVEnvDelete`          | Delete current selected venv in project in `python.nvim` state |
-| `:PythonDapPytestTestClass`  | Run `pytest` in dap against this test class under cursor       |
-| `:PythonDapPytestTestMethod` | Run `pytest` in dap against this test method under cursor      |
+| Command                   | Functionality                                                           |
+| ------------------------- | ----------------------------------------------------------------------- |
+| `:PythonVEnvDeleteSelect` | Select a venv to delete from `python.nvim` state                        |
+| `:PythonVEnvDelete`       | Delete current selected venv in project in `python.nvim` state          |
+| `:PythonDebugTest`        | Run Suite of tests with `neotest` in `dap` mode with `dap-python`       |
+| `:PythonDebugTestMethod`  | Run test function/method with `neotest` in `dap` mode with `dap-python` |
+| `:PythonDebugTestFile`    | Run test file with `neotest` in `dap` mode with `dap-python`            |
 
 ## Supported python package managers
 
@@ -111,3 +183,4 @@ return {
 Use this plugin if you want a more simple venv management plugin for your workflow.
 
 [go.nvim](https://github.com/ray-x/go.nvim) for inspiration.
+```

--- a/README.md
+++ b/README.md
@@ -182,7 +182,3 @@ return {
 Use this plugin if you want a more simple venv management plugin for your workflow.
 
 [go.nvim](https://github.com/ray-x/go.nvim) for inspiration.
-
-```
-
-```

--- a/examples/python_projects/pytest/pyproject.toml
+++ b/examples/python_projects/pytest/pyproject.toml
@@ -6,5 +6,6 @@ description = "Lovely Spam! Wonderful Spam!"
 readme = "README.md"
 license = "MIT"
 dependencies = [
-  "pytest"
+  "pytest",
+  "requests"
 ]

--- a/examples/python_projects/pytest/test_example.py
+++ b/examples/python_projects/pytest/test_example.py
@@ -4,3 +4,11 @@ def func(x):
 
 def test_answer():
     assert func(3) == 5
+
+
+def test_answer_2():
+    assert func(4) == 5
+
+
+def test_answer_3():
+    assert func(4) == 5

--- a/examples/python_projects/pytest/test_example_2.py
+++ b/examples/python_projects/pytest/test_example_2.py
@@ -1,0 +1,11 @@
+import requests
+
+
+def test_request():
+    req = requests.get("https://neovim.io")
+    assert "neovim" in req.text
+
+
+def test_request_fail():
+    req = requests.get("https://neovim.io")
+    assert "neovim" not in req.text

--- a/lazy.lua
+++ b/lazy.lua
@@ -5,6 +5,8 @@ return {
     { "mfussenegger/nvim-dap-python" },
     { "neovim/nvim-lspconfig" },
     { "MunifTanjim/nui.nvim" },
-    { "L3MON4D3/LuaSnip" }
+    { "L3MON4D3/LuaSnip" },
+    { "nvim-neotest/neotest" },
+    { "nvim-neotest/neotest-python" },
   }
 }

--- a/lua/python/config.lua
+++ b/lua/python/config.lua
@@ -45,6 +45,10 @@ local defaults = {
         height = "25"
       }
     }
+  },
+
+  test = {
+    test_runner = "pytest"
   }
 }
 

--- a/lua/python/dap/init.lua
+++ b/lua/python/dap/init.lua
@@ -17,8 +17,8 @@ end
 
 
 --- Read venv with debug py and launch callback
----@param callback function
-local function prepare_debugpy(callback)
+---@param callback? function
+function M.prepare_debugpy(callback)
   local venv = get_venv()
   if not venv then
     return
@@ -85,7 +85,7 @@ end
 function M.load_commands()
   local dap = require("dap")
   vim.api.nvim_create_user_command("PythonDap", function()
-    prepare_debugpy(function(venv)
+    M.prepare_debugpy(function(venv)
       vim.schedule(function()
         local dap_python = require("dap-python")
         dap_python.setup(vim.fs.joinpath(venv.path, "bin", "python3"), {})
@@ -108,31 +108,6 @@ function M.load_commands()
     end)
   end, {
     desc = "python.nvim: create or list dap configure"
-  })
-
-  vim.api.nvim_create_user_command("PythonDapPytestTestMethod", function()
-    prepare_debugpy(function(venv)
-      vim.schedule(function()
-        local dap_python = require("dap-python")
-        dap_python.setup(vim.fs.joinpath(venv.path, "bin", "python3"), {})
-        dap_python.test_runner = "pytest"
-        dap_python.test_method()
-      end)
-    end)
-  end, {
-    desc = "python.nvim: run test method with python dap"
-  })
-  vim.api.nvim_create_user_command("PythonDapPytestTestClass", function()
-    prepare_debugpy(function(venv)
-      vim.schedule(function()
-        local dap_python = require("dap-python")
-        dap_python.setup(vim.fs.joinpath(venv.path, "bin", "python3"), {})
-        dap_python.test_runner = "pytest"
-        dap_python.test_class()
-      end)
-    end)
-  end, {
-    desc = "python.nvim: run test class with python dap"
   })
 end
 

--- a/lua/python/init.lua
+++ b/lua/python/init.lua
@@ -48,6 +48,14 @@ function M.setup(opts)
       snip.load_snippets()
     end,
   })
+  vim.api.nvim_create_autocmd({ "BufEnter" }, {
+    pattern = "test_*.py",
+    group = id,
+    callback = function()
+      local test = require("python.test")
+      test.load_commands()
+    end,
+  })
 end
 
 return setmetatable(M, {

--- a/lua/python/test/init.lua
+++ b/lua/python/test/init.lua
@@ -1,0 +1,111 @@
+local M = {}
+
+local dap = require("python.dap")
+local config = require("python.config")
+
+local dap_python = require("dap-python")
+local neotest = require("neotest")
+
+-- Setup neotest and merge configuration to supply current venv
+local function neotest_setup()
+  local venv = require('python.venv').current_venv()
+
+  local neotest_python_config = {
+    runner = config.test.test_runner,
+  }
+
+  -- If in venv then executes tests within that venv
+  if venv then
+    neotest_python_config["python"] = vim.fs.joinpath(venv.path, "bin", "python3")
+  end
+  local neotest_config = require("neotest.config")
+
+  local new_config = {
+    adapters = {
+      require("neotest-python")(neotest_python_config)
+    }
+  }
+
+  -- Merge existing configuration
+  local merged = vim.tbl_deep_extend('force', neotest_config, new_config)
+  neotest.setup(merged)
+end
+
+local function neotest_test_method()
+  neotest_setup()
+  neotest.run.run()
+end
+
+local function neotest_test()
+  neotest_setup()
+  neotest.run.run({ suite = true })
+  neotest.summary.open()
+end
+
+local function neotest_debug_test()
+  dap.prepare_debugpy(function(venv)
+    vim.schedule(function()
+      dap_python.setup(vim.fs.joinpath(venv.path, "bin", "python3"), {})
+      neotest_setup()
+      neotest.run.run({ suite = true, strategy = "dap" })
+    end)
+  end)
+end
+
+local function neotest_test_file()
+  neotest_setup()
+  neotest.run.run(vim.fn.expand("%"))
+  neotest.summary.open()
+end
+
+local function neotest_debug_test_file()
+  dap.prepare_debugpy(function(venv)
+    vim.schedule(function()
+      dap_python.setup(vim.fs.joinpath(venv.path, "bin", "python3"), {})
+      neotest_setup()
+      neotest.run.run({ vim.fn.expand("%"), strategy = "dap", suite = false })
+    end)
+  end)
+end
+
+local function neotest_debug_test_method()
+  dap.prepare_debugpy(function(venv)
+    vim.schedule(function()
+      dap_python.setup(vim.fs.joinpath(venv.path, "bin", "python3"), {})
+      neotest_setup()
+      neotest.run.run({ strategy = "dap", suite = false })
+    end)
+  end)
+end
+
+function M.load_commands()
+  vim.api.nvim_create_user_command("PythonTest", function()
+    neotest_test()
+  end, { desc = "python.nvim: run test suite with neotest" })
+
+  vim.api.nvim_create_user_command("PythonTestMethod", function()
+    neotest_test_method()
+  end, { desc = "python.nvim: run test method with neotest" })
+
+  vim.api.nvim_create_user_command("PythonTestFile", function()
+    neotest_test_file()
+  end, { desc = "python.nvim: run test file with neotest" })
+
+  vim.api.nvim_create_user_command("PythonDebugTest", function()
+    neotest_debug_test()
+  end, { desc = "python.nvim: run test suite with neotest in debug mode" })
+
+  vim.api.nvim_create_user_command("PythonDebugTestMethod", function()
+    neotest_debug_test_method()
+  end, { desc = "python.nvim: run test method with neotest in debug mode" })
+
+  vim.api.nvim_create_user_command("PythonDebugTestFile", function()
+    neotest_debug_test_file()
+  end, { desc = "python.nvim: run test class with neotest in debug mode" })
+end
+
+return setmetatable(M, {
+  __index = function(_, k)
+    return require("python.test")[k]
+  end,
+})

--- a/lua/python/venv/init.lua
+++ b/lua/python/venv/init.lua
@@ -42,6 +42,7 @@ function M.set_venv_path(venv)
   end
 end
 
+---@return VEnv | nil
 function M.current_venv()
   return current_venv
 end


### PR DESCRIPTION
Fixes: #7 

Hook into neotest, neotest-python, dap, dap-python in order to run tests with neotest using a number if new commands

| `:PythonTest`        | Run Suite of tests with `neotest`                                                    |
| `:PythonTestMethod`  | Run test function/method with `neotest`                                              |
| `:PythonTestFile`    | Run test file with `neotest`                                                         |
| `:PythonDebugTest`        | Run Suite of tests with `neotest` in `dap` mode with `dap-python`       |
| `:PythonDebugTestMethod`  | Run test function/method with `neotest` in `dap` mode with `dap-python` |
| `:PythonDebugTestFile`    | Run test file with `neotest` in `dap` mode with `dap-python`            |
