### PR TITLE
feat: migrate to nvim-treesitter 'main'

### DIFF
--- a/lua/python/treesitter/init.lua
+++ b/lua/python/treesitter/init.lua
@@ -1,4 +1,3 @@
-local tsutil = require("nvim-treesitter.ts_utils")
 local nodes = require("python.treesitter.nodes")
 
 local PythonTreeSitter = {
@@ -8,7 +7,7 @@ local PythonTreeSitter = {
 }
 
 function PythonTreeSitter.test_ts_queries()
-  local current_node = tsutil.get_node_at_cursor()
+  local current_node = vim.treesitter.get_node()
   if not current_node then
     return
   end

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -18,51 +18,20 @@ vim.cmd("set rtp+=" .. runtime_path)
 require("luasnip").setup()
 require("luasnip.extras.fmt")
 require("luasnip.nodes.absolute_indexer")
-require("nvim-treesitter.locals")
-require("nvim-treesitter").setup()
 require("mini.test").setup()
 require("mini.doc").setup()
-require("nvim-treesitter.configs").setup({
-  modules = {
-    "highlight",
-  },
-  sync_install = false,
-  auto_install = true,
-  ignore_install = {},
-  ensure_installed = {},
-  highlight = {
-    enable = true,
-  },
+
+-- Setup nvim-treesitter
+require("nvim-treesitter").install("python")
+
+vim.api.nvim_create_autocmd("FileType", {
+  group = vim.api.nvim_create_augroup("PythonTreesitter", { clear = true }),
+  pattern = "python",
+  desc = "Enable treesitter highlighting and indentation",
+  callback = function(event)
+    local buf = event.buf
+
+    -- Start highlighting
+    pcall(vim.treesitter.start, buf, "python")
+  end,
 })
-
--- Clean path for use in a prefix comparison
----@param input string
----@return string
-local function clean_path(input)
-  local pth = vim.fn.fnamemodify(input, ":p")
-  if vim.fn.has("win32") == 1 then
-    pth = pth:gsub("/", "\\")
-  end
-  return pth
-end
-
-local function ts_is_installed(lang)
-  local matched_parsers = vim.api.nvim_get_runtime_file("parser/" .. lang .. ".so", true) or {}
-  local configs = require("nvim-treesitter.configs")
-  local install_dir = configs.get_parser_install_dir()
-  if not install_dir then
-    return false
-  end
-  install_dir = clean_path(install_dir)
-  for _, path in ipairs(matched_parsers) do
-    local abspath = clean_path(path)
-    if vim.startswith(abspath, install_dir) then
-      return true
-    end
-  end
-  return false
-end
-
-if not ts_is_installed("python") then
-  vim.cmd("TSInstallSync python")
-end


### PR DESCRIPTION
This PR migrates the plugin to use the `vim.treesitter.*` API, as the APIs from `nvim-treesitter` have been removed in the `main` branch. This should be compatible with both the `master` and `main` version of `nvim-treesitter` (except for `minimal_init.lua`, which assumes the `main` version).

Copilot was used to make these changes, with manual cleanup, testing and review.