### PR TITLE
fix(config): invalid key checking in config handles lists and doesn't…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ["v0.10.4", "v0.11.3", "nightly"]
+        neovim_version: ["v0.11.3", "nightly"]
         include:
           - os: macos-latest
             neovim_version: v0.11.3

--- a/lua/python/config.lua
+++ b/lua/python/config.lua
@@ -184,9 +184,18 @@ local function tbl_deep_extend_existing(target, source, prev_key)
         -- Overwrite existing key
         target[key] = value
       end
+    elseif type(key) == "number" then
+      -- If the key is a number then we can assume 
+      -- that this is a table that is supposed to be a list
+      goto continue
     else
-      error(("python.nvim: user inputted config key: %s is not found in config table: %s"):format(key, prev_key))
+      vim.notify(
+        ("python.nvim: user inputted config key: %s is not found in config table: %s"):format(key, prev_key),
+        vim.log.levels.WARN
+      )
+      goto continue
     end
+    ::continue::
   end
   return target
 end

--- a/lua/python/config.lua
+++ b/lua/python/config.lua
@@ -185,7 +185,7 @@ local function tbl_deep_extend_existing(target, source, prev_key)
         target[key] = value
       end
     elseif type(key) == "number" then
-      -- If the key is a number then we can assume 
+      -- If the key is a number then we can assume
       -- that this is a table that is supposed to be a list
       goto continue
     else

--- a/tests/test_config.lua
+++ b/tests/test_config.lua
@@ -34,9 +34,11 @@ T["setup"]["override"] = function()
 end
 
 T["setup"]["not_found"] = function()
-  expect.error(function()
-    child.lua("config.setup({ ui = { popup = {foobar = true}} })")
-  end, ".*user inputted config key: foobar is not found.*")
+  child.lua("config.setup({ ui = { popup = {foobar = true}} })")
+  eq(
+    child.lua([[return vim.split(vim.fn.execute("messages", "silent"), "\n")]]),
+    { "", "python.nvim: user inputted config key: foobar is not found in config table: config.ui.popup" }
+  )
 end
 
 -- Return test set which will be collected and execute inside `MiniTest.run()`


### PR DESCRIPTION
… throw errors

instead of crashing python.nvim, show a notification as a warning. Be able to handle list-type tables by not having it be an error if the key is a number (indicating its a list)